### PR TITLE
Update `master` for Wren Security Builds

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="forgerock-bloomfilter"
+export BINTRAY_PACKAGE="wrensec-bloomfilter"
+export JFROG_PACKAGE="org/forgerock/commons/bloomfilter-guice"

--- a/bloomfilter-core/src/main/java/org/forgerock/bloomfilter/BloomFilter.java
+++ b/bloomfilter-core/src/main/java/org/forgerock/bloomfilter/BloomFilter.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.forgerock.bloomfilter;
@@ -19,29 +20,32 @@ package org.forgerock.bloomfilter;
 import java.util.Collection;
 
 /**
- * General interface contract for implementations of <a href="http://en.wikipedia.org/wiki/Bloom_filter">Bloom
- * Filters</a>. A Bloom Filter is a Set-like data structure that uses only a few bits of memory per element stored.
- * This allows very large numbers (billions) of elements to be stored in-memory, with the trade-off being that set
- * containment can now return false positives. That is, the Bloom Filter can say for certain if a given element is
- * definitely <em>not</em> in the set, but it cannot say for certain whether it is. Bloom Filters are therefore
- * appropriate as a quick initial check to reduce load on a more expensive but more accurate storage mechanism (e.g.,
- * a database) or where some level of false positives is tolerable. The expected usage pattern for the former case
- * would be something like the following psuedo-code:
- * <pre>
- *     BloomFilter&lt;T&gt filter = ...;
- *     Set&lt;T&gt; expensiveSet = ...; // e.g. database, web-service
- *     if (filter.mightContain(element)) {
- *         // Perform the more expensive check to be sure
- *         return expensive.contains(element);
- *     }
- *     return false;
+ * General interface contract for implementations of Bloom Filters.
+ *
+ * <p>A Bloom Filter is a Set-like data structure that uses only a few bits of memory per element
+ * stored. This allows very large numbers (billions) of elements to be stored in-memory, with the
+ * trade-off being that set containment can now return false positives. That is, the Bloom Filter
+ * can say for certain if a given element is definitely <em>not</em> in the set, but it cannot say
+ * for certain whether it is. Bloom Filters are therefore appropriate as a quick initial check to
+ * reduce load on a more expensive but more accurate storage mechanism (e.g., a database) or where
+ * some level of false positives is tolerable. The expected usage pattern for the former case would
+ * be something like the following psuedo-code:
+ * <pre>{@code
+ *   BloomFilter<T> filter = ...;
+ *   Set<T> expensiveSet = ...; // e.g. database, web-service
+ *   if (filter.mightContain(element)) {
+ *     // Perform the more expensive check to be sure
+ *     return expensive.contains(element);
+ *   }
+ *   return false;
+ * }
  * </pre>
- * Note: this assumes that the Bloom Filter is kept in-sync with the definitive set! How this is accomplished is
- * outside of the scope of this package.
- * <p/>
- * All Bloom Filter implementations in this package allow the probability of false positives (FPP) to be specified,
- * and the implementation will adjust the amount of memory used to ensure the given level of accuracy for the
- * expected number of elements.
+ * Note: this assumes that the Bloom Filter is kept in-sync with the definitive set! How this is
+ * accomplished is outside of the scope of this package.
+ *
+ * <p>All Bloom Filter implementations in this package allow the probability of false positives
+ * (FPP) to be specified, and the implementation will adjust the amount of memory used to ensure the
+ * given level of accuracy for the expected number of elements.
  *
  * @param <E> the type of elements contained in the bloom filter.
  * @see <a href="http://en.wikipedia.org/wiki/Bloom_filter">Bloom Filter Wikipedia entry</a>.
@@ -49,8 +53,9 @@ import java.util.Collection;
 public interface BloomFilter<E> {
 
     /**
-     * Adds the specified element to this set if it is not already possibly present. After a call to this method,
-     * subsequent calls to {@link #mightContain(Object)} will return {@code true} for the same object.
+     * Adds the specified element to this set if it is not already possibly present. After a call to
+     * this method, subsequent calls to {@link #mightContain(Object)} will return {@code true} for
+     * the same object.
      *
      * @param element the element to add to this set.
      */
@@ -64,12 +69,14 @@ public interface BloomFilter<E> {
     void addAll(Collection<? extends E> elements);
 
     /**
-     * Checks if the given element <em>might</em> be a member of this set. If this method returns {@code false}, then
-     * the given object is definitely not a member of the set. If the result is {@code true} then the object may or
-     * may not be a member of this set, with a certain probability of false positives.
+     * Checks if the given element <em>might</em> be a member of this set. If this method returns
+     * {@code false}, then the given object is definitely not a member of the set. If the result is
+     * {@code true} then the object may or may not be a member of this set, with a certain
+     * probability of false positives.
      *
      * @param element the element to check for membership in this set.
-     * @return {@code false} if the element is definitely not in the set, or {@code true} if it might be.
+     * @return {@code false} if the element is definitely not in the set, or {@code true} if it
+     *         might be.
      */
     boolean mightContain(E element);
 

--- a/bloomfilter-core/src/main/java/org/forgerock/bloomfilter/ConcurrentRollingBloomFilter.java
+++ b/bloomfilter-core/src/main/java/org/forgerock/bloomfilter/ConcurrentRollingBloomFilter.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.forgerock.bloomfilter;
@@ -24,15 +25,16 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
 
 /**
- * A thread-safe implementation of a Bloom Filter that can expand over time to accommodate arbitrary numbers of
- * elements, while also allowing old elements to be deleted after they have expired. Rolling bloom filters are useful
- * for maintaining on-going blacklists of short-lived elements.
- * <p/>
- * This implementation is optimised for concurrent read performance. Concurrent writes performance is likely to be
- * considerably slower than reads, so this implementation is only suitable for situations where read performance is
- * critical and writes are relatively rare. Write performance may be improved by batching writes via the
- * {@link #addAll(Collection)} method, or by using some external synchronisation mechanism to perform pre-emptive
- * locking (at the cost of reducing read performance).
+ * A thread-safe implementation of a Bloom Filter that can expand over time to accommodate arbitrary
+ * numbers of elements, while also allowing old elements to be deleted after they have expired.
+ * Rolling bloom filters are useful for maintaining on-going blacklists of short-lived elements.
+ *
+ * <p>This implementation is optimised for concurrent read performance. Concurrent writes
+ * performance is likely to be considerably slower than reads, so this implementation is only
+ * suitable for situations where read performance is critical and writes are relatively rare. Write
+ * performance may be improved by batching writes via the {@link #addAll(Collection)} method, or by
+ * using some external synchronisation mechanism to perform pre-emptive locking (at the cost of
+ * reducing read performance).
  */
 @ThreadSafe
 public final class ConcurrentRollingBloomFilter<T> implements BloomFilter<T> {

--- a/bloomfilter-core/src/main/java/org/forgerock/bloomfilter/package-info.java
+++ b/bloomfilter-core/src/main/java/org/forgerock/bloomfilter/package-info.java
@@ -12,19 +12,21 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 /**
  * <h1>ForgeRock Bloom Filters</h1>
- * Implementations of thread-safe, scalable and rolling Bloom Filters. These are Set-like data structures that can
- * scale to very large numbers of entries while only using a small amount of memory (a few bits) per element. The
- * trade-off is that the set membership operation may report false positives (i.e., it may claim that an item is a
- * member of the set when it isn't). The probability of false positives can be tuned by increasing the amount of
- * memory used.
- * <p/>
- * The {@link org.forgerock.bloomfilter.BloomFilter} interface describes the general contract of bloom filters in
- * more detail, and the {@link org.forgerock.bloomfilter.BloomFilters} utility class provides static factory and
- * builder methods for constructing bloom filters for various requirements.
+ * Implementations of thread-safe, scalable and rolling Bloom Filters. These are Set-like data
+ * structures that can scale to very large numbers of entries while only using a small amount of
+ * memory (a few bits) per element. The trade-off is that the set membership operation may report
+ * false positives (i.e., it may claim that an item is a member of the set when it isn't). The
+ * probability of false positives can be tuned by increasing the amount of memory used.
+ *
+ * <p>The {@link org.forgerock.bloomfilter.BloomFilter} interface describes the general contract of
+ * bloom filters in more detail, and the {@link org.forgerock.bloomfilter.BloomFilters} utility
+ * class provides static factory and builder methods for constructing bloom filters for various
+ * requirements.
  *
  * <h2>Example</h2>
  * <pre>{@code
@@ -43,57 +45,64 @@
  * }</pre>
  *
  * <h2>Scalable and Rolling Bloom Filters</h2>
- * Beyond fixed-capacity Bloom Filters, whose probability of false positives rapidly increases once they have reached
- * capacity, this package also provides <em>scalable</em> and <em>rolling</em> Bloom Filters. The former are an
- * efficient and flexible implementation of the classic <a
- * href="http://www.sciencedirect.com/science/article/pii/S0020019006003127">Scalable Bloom Filters</a> paper by
- * Almeida et al., <em>Information Processing Letters</em>, 101(6), p.255&ndash;261, 2007. The latter are a
- * time-limited variation on this idea, whereby buckets in the scalable bloom filter can expire over time, freeing up
- * memory. The buckets are then recycled ensuring that memory usage is kept reasonable.
- * <p/>
- * Scalable Bloom Filters are useful for storing sets of objects where you do not know <em>a priori</em> the number
- * of elements you might need to store. By dynamically expanding the capacity of the Bloom Filter, as well as
- * reducing the false positive probability of subsequent buckets according to a geometric series, the Scalable Bloom
- * Filter can expand to accommodate orders of magnitude more elements that originally estimated, while preserving the
- * overall configured false positive probability. Use the {@link
- * org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withFalsePositiveProbabilityScaleFactor(double)} and
- * {@link org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withCapacityGrowthFactor(double)} builder methods
- * to configure the scale factors for capacity and false positive probability in these implementations. The defaults
- * (0.8 and 2.0 respectively) provide a good trade off of memory growth and performance.
- * <p/>
- * Rolling Bloom Filters allow elements in a Bloom Filter to expire over time. Use the {@link
+ * Beyond fixed-capacity Bloom Filters, whose probability of false positives rapidly increases once
+ * they have reached capacity, this package also provides <em>scalable</em> and <em>rolling</em>
+ * Bloom Filters. The former are an efficient and flexible implementation of the classic <a
+ * href="http://www.sciencedirect.com/science/article/pii/S0020019006003127">Scalable Bloom
+ * Filters</a> paper by Almeida et al., <em>Information Processing Letters</em>, 101(6),
+ * p.255&ndash;261, 2007. The latter are a time-limited variation on this idea, whereby buckets in
+ * the scalable bloom filter can expire over time, freeing up memory. The buckets are then recycled
+ * ensuring that memory usage is kept reasonable.
+ *
+ * <p>Scalable Bloom Filters are useful for storing sets of objects where you do not know
+ * <em>a priori</em> the number of elements you might need to store. By dynamically expanding the
+ * capacity of the Bloom Filter, as well as reducing the false positive probability of subsequent
+ * buckets according to a geometric series, the Scalable Bloom Filter can expand to accommodate
+ * orders of magnitude more elements that originally estimated, while preserving the overall
+ * configured false positive probability. Use the {@link
+ * org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withFalsePositiveProbabilityScaleFactor(double)}
+ * and {@link org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withCapacityGrowthFactor(double)}
+ * builder methods to configure the scale factors for capacity and false positive probability in
+ * these implementations. The defaults (0.8 and 2.0 respectively) provide a good trade off of memory
+ * growth and performance.
+ *
+ * <p>Rolling Bloom Filters allow elements in a Bloom Filter to expire over time. Use the {@link
  * org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withExpiryStrategy(org.forgerock.bloomfilter.ExpiryStrategy)}
- * method to configure how elements in your Bloom Filter will expire. By default, elements do not expire.
+ * method to configure how elements in your Bloom Filter will expire. By default, elements do not
+ * expire.
  *
  * <h2>Concurrency Strategies</h2>
- * The implementations provided are currently all thread-safe, and adopt a flexible approach to concurrency control.
- * Two concurrency strategies are currently supported:
+ * The implementations provided are currently all thread-safe, and adopt a flexible approach to
+ * concurrency control. Two concurrency strategies are currently supported:
  * <ul>
- *     <li><em>SYNCHRONIZED</em> - uses synchronized blocks to ensure mutual exclusion of critical sections. For
- *     fixed-capacity bloom filters all methods are mutually exclusive. For scalable and rolling bloom filters,
- *     individual buckets are independently synchronized, allowing some additional concurrency. This implementation
- *     provides moderate read and write performance.</li>
+ *     <li><em>SYNCHRONIZED</em> - uses synchronized blocks to ensure mutual exclusion of critical
+ *     sections. For fixed-capacity bloom filters all methods are mutually exclusive. For scalable
+ *     and rolling bloom filters, individual buckets are independently synchronized, allowing some
+ *     additional concurrency. This implementation provides moderate read and write
+ *     performance.</li>
  *
- *     <li><em>COPY_ON_WRITE</em> - provides very fast read access at the cost of extremely expensive write
- *     operations, which must make a copy of (part of) the Bloom Filter to apply any changes. Write batching (see
- *     below) can be used to amortize write costs over many operations, however this implementation will still
- *     create additional temporary garbage and pressure on the garbage collector. Suitable for situations in which
- *     read performance (mightContain) is paramount and writes are relatively rare (and can tolerate increased
- *     latency).</li>
+ *     <li><em>COPY_ON_WRITE</em> - provides very fast read access at the cost of extremely
+ *     expensive write operations, which must make a copy of (part of) the Bloom Filter to apply any
+ *     changes. Write batching (see below) can be used to amortize write costs over many operations,
+ *     however this implementation will still create additional temporary garbage and pressure on
+ *     the garbage collector. Suitable for situations in which read performance (mightContain) is
+ *     paramount and writes are relatively rare (and can tolerate increased latency).</li>
  * </ul>
  * Use the {@link org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withConcurrencyStrategy(org.forgerock.bloomfilter.ConcurrencyStrategy)}
  * method to specify the concurrency strategy to use. The default is COPY_ON_WRITE.
  *
  * <h2>Write Batching</h2>
- * To compensate for the relatively poor performance of COPY_ON_WRITE concurrency (see previous section), the
- * implementation supports <em>write batching</em>. When enabled, individual calls to the {@link
- * org.forgerock.bloomfilter.BloomFilter#add(java.lang.Object)} method will be buffered in a traditional concurrent
- * collection class until the write batch size is reached. At this point, the buffer will be flushed to the
- * underlying bloom filter implementation in a single operation. This amortizes the cost of copying the underlying
- * collection, at the cost of increased worst-case latencies (when the buffer is flushed) and increased memory churn.
- * The implementation is very highly optimised, supporting very high throughput of both writes and reads, and so is a
- * good choice when throughput is paramount and occasional high write latencies can be tolerated. Use
- * {@link org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withWriteBatchSize(int)} to enable write batching.
+ * To compensate for the relatively poor performance of COPY_ON_WRITE concurrency (see previous
+ * section), the implementation supports <em>write batching</em>. When enabled, individual calls to
+ * the {@link org.forgerock.bloomfilter.BloomFilter#add(java.lang.Object)} method will be buffered
+ * in a traditional concurrent collection class until the write batch size is reached. At this
+ * point, the buffer will be flushed to the underlying bloom filter implementation in a single
+ * operation. This amortizes the cost of copying the underlying collection, at the cost of increased
+ * worst-case latencies (when the buffer is flushed) and increased memory churn. The implementation
+ * is very highly optimised, supporting very high throughput of both writes and reads, and so is a
+ * good choice when throughput is paramount and occasional high write latencies can be tolerated.
+ * Use {@link org.forgerock.bloomfilter.BloomFilters.BloomFilterBuilder#withWriteBatchSize(int)} to
+ * enable write batching.
  *
  * @see <a href="http://en.wikipedia.org/wiki/Bloom_filter">Bloom Filter Wikipedia entry</a>
  */

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock</groupId>
-        <artifactId>forgerock-parent</artifactId>
-        <version>2.0.4</version>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>2.2.0</version>
     </parent>
 
     <groupId>org.forgerock.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -25,8 +26,9 @@
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-bloomfilter</artifactId>
     <version>1.0.2-SNAPSHOT</version>
-    <name>ForgeRock Bloom Filters</name>
+    <name>Wren Security Bloom Filters</name>
     <description>Thread-safe implementations of scalable and rolling Bloom Filters.</description>
+    <url>http://wrensecurity.org/</url>
     <packaging>pom</packaging>
     <licenses>
         <license>
@@ -40,12 +42,16 @@
         </license>
     </licenses>
 
+    <issueManagement>
+         <system>GitHub Issues</system>
+         <url>https://github.com/WrenSecurity/wrensec-bloomfilter/issues</url>
+    </issueManagement>
+
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-bloomfilter.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-bloomfilter.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-bloomfilter/browse</url>
-      <tag>HEAD</tag>
-  </scm>
+        <url>https://github.com/WrenSecurity/wrensec-bloomfilter</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-bloomfilter.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-bloomfilter.git</developerConnection>
+    </scm>
 
     <properties>
         <hdrhistogram.version>2.1.4</hdrhistogram.version>
@@ -116,12 +122,17 @@
 
     <repositories>
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,31 +13,39 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
-  ~ Portions Copyright 2017 Wren Security.
+  ~ Portions Copyright 2018 Wren Security.
   -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock</groupId>
         <artifactId>forgerock-parent</artifactId>
         <version>2.0.4</version>
     </parent>
+
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-bloomfilter</artifactId>
     <version>1.0.2-SNAPSHOT</version>
     <name>Wren Security Bloom Filters</name>
     <description>Thread-safe implementations of scalable and rolling Bloom Filters.</description>
+
     <url>http://wrensecurity.org/</url>
+
     <packaging>pom</packaging>
+
     <licenses>
         <license>
             <name>CDDL-1.0</name>
             <url>http://www.opensource.org/licenses/CDDL-1.0</url>
+
             <comments>Common Development and Distribution License (CDDL) 1.0.
                 This license applies to OpenAM source code as indicated in the
                 sources themselves.
             </comments>
+
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -73,12 +81,14 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${jsr.305.version}</version>
                 <optional>true</optional>
             </dependency>
+
             <dependency>
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
@@ -102,16 +112,19 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jcl</artifactId>
@@ -141,6 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -152,5 +166,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
- Leverages changes from @siepkes and me for getting this buildable with Wren artifacts on JDK8:
-- Modifies the POMs to build using Wren's repos.
-- Updates branding to call this Wren Security Bloom Filters.
-- Adds Wren Deploy RC file.
- Bumps version to the SNAPSHOT branch.